### PR TITLE
add a link to a tutorial that covers some of the basics

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,6 +18,7 @@ Inspired by the [awesome](https://github.com/sindresorhus/awesome) list thing.
 
 - [Microsoft Open Technologies](https://github.com/MSOpenTech) - Windows ports of non-Microsoft technologies.
 - [Microsoft Node.js Guidelines](https://github.com/Microsoft/nodejs-guidelines) - Tips, tricks, and resources for working with Node.js on Microsoft platforms.
+- [Writing Cross-Platform Node.js](http://shapeshed.com/writing-cross-platform-node/) - a great tutorial covering many common issues that arise when writing cross-platform code: path creation, script execution, newline characters.
 
 ## Known Issues
 


### PR DESCRIPTION
Based on @jamestalmage's suggestion (fixes #6) adds a link to a tutorial that introduces some basic concepts, regarding writing portable code.