### PR TITLE
add `electronjs` to Desktop UI

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,7 @@
 
 - [open](https://github.com/sindresorhus/open) - Opens stuff like websites, files, executables. Cross-platform.
 - [node-notifier](https://github.com/mikaelbr/node-notifier) - Cross-platform desktop notifications.
+- [electron](https://electronjs.org/) - Build cross-platform desktop apps with JavaScript, HTML, and CSS.
 
 ### Windows registry
 


### PR DESCRIPTION
I don't sure that we should add `electron` to `Desktop UI` or create a new tag