### PR TITLE
update link for guide

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -18,4 +18,4 @@ Thank you for your suggestions!
 
 ### Updating your PR
 
-A lot of times, making a PR adhere to the standards above can be difficult. If the maintainers notice anything that we'd like changed, we'll ask you to edit your PR before we merge it. If you're not sure how to do that, [here is a guide](https://github.com/RichardLitt/docs/blob/master/amending-a-commit-guide.md) on the different ways you can update your PR so that we can merge it.
+A lot of times, making a PR adhere to the standards above can be difficult. If the maintainers notice anything that we'd like changed, we'll ask you to edit your PR before we merge it. If you're not sure how to do that, [here is a guide](https://github.com/RichardLitt/knowledge/blob/master/github/amending-a-commit-guide.md) on the different ways you can update your PR so that we can merge it.


### PR DESCRIPTION
https://github.com/RichardLitt/docs changed to https://github.com/RichardLitt/knowledge