### PR TITLE
Add `global-cache-dir`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,7 @@
 - [fs-extra](https://github.com/jprichardson/node-fs-extra) - Combines `graceful-fs` with better JSON file reading and promises.
 - [any-path](https://github.com/bcoe/any-path) - Use Windows and POSIX paths interchangeably when fetching values from an object.
 - [dev-null-cli](https://github.com/sindresorhus/dev-null-cli) - Cross-platform `/dev/null`.
+- [global-cache-dir](https://github.com/ehmicky/global-cache-dir) - Get the global OS-specific cache directory.
 
 ### Signals
 


### PR DESCRIPTION
This adds [`global-cache-dir`](https://github.com/ehmicky/global-cache-dir), which retrieves the global cache directory in a cross-platform way.

---

Please fill in the following section:
  - [x] the title is clear and descriptive.
  - [x] you've read the [contribution guidelines](https://github.com/bcoe/awesome-cross-platform-nodejs/blob/master/contributing.md).

If you're adding a link, please make sure it is:
  - [x] related to OS-specific behavior.
  - [x] solving cross-platform issues present in core Node.js.
